### PR TITLE
supply backing type, use const fn for constructors

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,11 +12,7 @@ keywords = ["data-structure", "integer", "library", "utility", "wrapper"]
 categories = ["data-structures", "rust-patterns"]
 
 [dependencies]
-derive_more = "0.99.7"
 num = { version = "0.2.1", optional = true }
-
-[dev-dependencies]
-anyhow = "1.0.31"
 
 [features]
 default = []


### PR DESCRIPTION
The numeric storage type can now be supplied as a generic type rather than
hardcoding to `usize`. The implementations for traits are moved to macros.

The bounds are now supplied using `i128`, allowing both negative bounds and
bigger bounds than `usize`.

The constructors are now `const fn`s and will panic at compile time too
if used in a `const` context.